### PR TITLE
Not validate undefined endpoints

### DIFF
--- a/chocs_middleware/openapi/middleware.py
+++ b/chocs_middleware/openapi/middleware.py
@@ -57,7 +57,7 @@ class OpenApiMiddleware(Middleware):
         try:
             open_api_uri_schema = self.openapi.query(f"/paths/{path}")
             open_api_method_schema = open_api_uri_schema[method_name]
-        except KeyError:
+        except (KeyError, LookupError):
             return validators
 
         if self.validators["body"]:

--- a/tests/openapi/test_middleware.py
+++ b/tests/openapi/test_middleware.py
@@ -79,3 +79,24 @@ def test_can_pass_validate_request_parameters() -> None:
 
     # then
     assert response == success_response
+
+
+def test_request_with_no_openapi_definition_is_valid() -> None:
+    # given
+    dirname = path.dirname(__file__)
+    middleware = OpenApiMiddleware(path.join(dirname, "../fixtures/openapi.yml"))
+    request = HttpRequest(
+        HttpMethod.GET,
+        "/non_existent_endpoint_XYZ",
+    )
+    request.route = Route("/non_existent_endpoint_XYZ")
+    success_response = HttpResponse()
+
+    def _next(request: HttpRequest) -> HttpResponse:
+        return success_response
+
+    # when
+    response = middleware.handle(request, _next)
+
+    # then
+    assert response == success_response


### PR DESCRIPTION
Currently, endpoints that do not have a definition in the OpenAPI file, which can make sense for endpoints that cannot be property validated with this middleware (E.g. graphql endpoints), should be ignored.

This PR adds that feature.