### PR TITLE
Fixing Release pathing to dist file

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
         uses: actions/upload-artifact@v1
         with:
           name: chocs-middleware-openapi-${{ steps.tag.outputs.tag }}.tar.gz
-          path: dist/chocs_middleware.openapi-${{ steps.tag.outputs.tag }}.tar.gz
+          path: dist/chocs_middleware_openapi-${{ steps.tag.outputs.tag }}.tar.gz
       - name: Publish release
         env:
           POETRY_PYPI_TOKEN_PYPI: ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
New poetry distributions don't allow ' . ' in path to dist files. Therefore I'm alligning the workflow to new poetry specifications.