### PR TITLE
Standalone Bson Deprecated and so should be removed

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -59,18 +59,6 @@ jupyter = ["ipython (>=7.8.0)", "tokenize-rt (>=3.2.0)"]
 uvloop = ["uvloop (>=0.15.2)"]
 
 [[package]]
-name = "bson"
-version = "0.5.10"
-description = "BSON codec for Python"
-category = "main"
-optional = false
-python-versions = "*"
-
-[package.dependencies]
-python-dateutil = ">=2.4.0"
-six = ">=1.9.0"
-
-[[package]]
 name = "chocs"
 version = "1.6.1"
 description = "Lightweight and powerful WSGI/AWS lambda framework for rapid building rest applications."
@@ -361,17 +349,6 @@ pytest = ">=2.7"
 dev = ["pre-commit", "tox"]
 
 [[package]]
-name = "python-dateutil"
-version = "2.8.2"
-description = "Extensions to the standard Python datetime module"
-category = "main"
-optional = false
-python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
-
-[package.dependencies]
-six = ">=1.5"
-
-[[package]]
 name = "pyyaml"
 version = "5.4.1"
 description = "YAML parser and emitter for Python"
@@ -383,7 +360,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
 name = "six"
 version = "1.16.0"
 description = "Python 2 and 3 compatibility utilities"
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
 
@@ -446,7 +423,7 @@ python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "970660956a366f0adec81d3afa77025c7becc9c2c78e6481e5fa3690c108f3ed"
+content-hash = "b0bb7472f9fd64efb444f8c8bfc3d05e079b0a9349bf1792966eb60adc0b0956"
 
 [metadata.files]
 astroid = [
@@ -482,9 +459,6 @@ black = [
     {file = "black-22.10.0-cp39-cp39-win_amd64.whl", hash = "sha256:432247333090c8c5366e69627ccb363bc58514ae3e63f7fc75c54b1ea80fa7de"},
     {file = "black-22.10.0-py3-none-any.whl", hash = "sha256:c957b2b4ea88587b46cf49d1dc17681c1e672864fd7af32fc1e9664d572b3458"},
     {file = "black-22.10.0.tar.gz", hash = "sha256:f513588da599943e0cde4e32cc9879e825d58720d6557062d1098c5ad80080e1"},
-]
-bson = [
-    {file = "bson-0.5.10.tar.gz", hash = "sha256:d6511b2ab051139a9123c184de1a04227262173ad593429d21e443d6462d6590"},
 ]
 chocs = [
     {file = "chocs-1.6.1-py3-none-any.whl", hash = "sha256:bf2bb843ce718d1a9ad8330f22da9fd9b92042b77059cbf5eded5de2206f445a"},
@@ -669,10 +643,6 @@ pytest-cov = [
 pytest-mock = [
     {file = "pytest-mock-1.13.0.tar.gz", hash = "sha256:e24a911ec96773022ebcc7030059b57cd3480b56d4f5d19b7c370ec635e6aed5"},
     {file = "pytest_mock-1.13.0-py2.py3-none-any.whl", hash = "sha256:67e414b3caef7bff6fc6bd83b22b5bc39147e4493f483c2679bc9d4dc485a94d"},
-]
-python-dateutil = [
-    {file = "python-dateutil-2.8.2.tar.gz", hash = "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86"},
-    {file = "python_dateutil-2.8.2-py2.py3-none-any.whl", hash = "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"},
 ]
 pyyaml = [
     {file = "PyYAML-5.4.1-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:3b2b1824fe7112845700f815ff6a489360226a5609b96ec2190a45e62a9fc922"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "chocs_middleware.openapi"
-version = "1.2.0"
+version = "1.2.1"
 description = "Middleware to validate incoming requests with openapi spec."
 authors = [
     "Dawid Kraczkowski <dawid.kraczkowski@gmail.com>"
@@ -33,7 +33,6 @@ classifiers = [
 python = "^3.8"
 chocs = "^1.6.1"
 opyapi = "^1.3.1"
-bson = "^0.5.10"
 
 [tool.poetry.dev-dependencies]
 pytest = "^4.1.0"


### PR DESCRIPTION
bson is no longer a supported independent library. It’s making projects that we own that depend on both Chocs-middleware-openapi and pymongo to have clashing bson libraries as Pymongo has its own implementation of Bson. There is a local workaround, 
`pip uninstall pymongo` then `pip uninstall bson` and then `pip install pymongo`, but this workaround doesn't hold on AWS.

Why was BSON included in chocs-middleware-openapi originally?

Relevant links:
https://github.com/py-bson/bson , py 3.6 support at best - https://github.com/mongodb/mongo-python-driver/  Has its own BSON implementation